### PR TITLE
Sheet view의 clipsToBounds를 설정 가능하도록 옵션 추가

### DIFF
--- a/Example/ColorViewController.swift
+++ b/Example/ColorViewController.swift
@@ -26,6 +26,12 @@ class ColorViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = color
+        self.view.clipsToBounds = false
+
+        let rectangleView = UIView(frame: CGRect(x: 100, y: -100, width: 200, height: 300))
+        rectangleView.backgroundColor = .blue
+        rectangleView.layer.cornerRadius = 20.0
+        view.addSubview(rectangleView)
 
         let contentSizeLabel = UILabel(frame: CGRect(x: 0, y: 0, width: preferredContentSize.width, height: preferredContentSize.height))
         contentSizeLabel.backgroundColor = UIColor.cyan.withAlphaComponent(0.5)

--- a/Example/ViewController.swift
+++ b/Example/ViewController.swift
@@ -50,6 +50,12 @@ class ViewController: UIViewController {
         buttons.append(button)
 
         button = UIButton(type: .system)
+        button.setTitle("medium out of bounds", for: .normal)
+        button.addTarget(self, action: #selector(presentModernMediumOutOfBounds), for: .touchUpInside)
+        button.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        buttons.append(button)
+
+        button = UIButton(type: .system)
         button.setTitle("medium + grabber", for: .normal)
         button.addTarget(self, action: #selector(presentModernMediumGrabber), for: .touchUpInside)
         button.frame = CGRect(x: 0, y: 0, width: width, height: height)
@@ -128,6 +134,12 @@ class ViewController: UIViewController {
         button = UIButton(type: .system)
         button.setTitle("medium", for: .normal)
         button.addTarget(self, action: #selector(presentLegacyMedium), for: .touchUpInside)
+        button.frame = CGRect(x: 0, y: 0, width: width, height: height)
+        buttons.append(button)
+
+        button = UIButton(type: .system)
+        button.setTitle("medium out of bounds", for: .normal)
+        button.addTarget(self, action: #selector(presentLegacyMediumOutOfBounds), for: .touchUpInside)
         button.frame = CGRect(x: 0, y: 0, width: width, height: height)
         buttons.append(button)
 
@@ -219,6 +231,13 @@ class ViewController: UIViewController {
         let sheetContent = ColorViewController(color: .orange)
         let sheet = BottomSheetPresenter(content: sheetContent)
         sheet.detents = [.medium, .large]
+        sheet.present(from: self)
+    }
+
+    @objc func presentModernMediumOutOfBounds() {
+        let sheetContent = ColorViewController(color: .orange)
+        let sheet = BottomSheetPresenter(content: sheetContent, allowsContentOutOfBounds: true)
+        sheet.detents = [.medium]
         sheet.present(from: self)
     }
 
@@ -325,6 +344,13 @@ class ViewController: UIViewController {
     @objc func presentLegacyMedium() {
         let sheetContent = ColorViewController(color: .orange)
         let sheet = BottomSheetPresenter(content: sheetContent, useLegacyForcely: true)
+        sheet.detents = [.medium]
+        sheet.present(from: self)
+    }
+
+    @objc func presentLegacyMediumOutOfBounds() {
+        let sheetContent = ColorViewController(color: .orange)
+        let sheet = BottomSheetPresenter(content: sheetContent, useLegacyForcely: true, allowsContentOutOfBounds: true)
         sheet.detents = [.medium]
         sheet.present(from: self)
     }

--- a/Sources/BottomSheetPresenter.swift
+++ b/Sources/BottomSheetPresenter.swift
@@ -46,11 +46,14 @@ public class BottomSheetPresenter {
     public var detents: [BottomSheetDetent] = [.large]
     public var prefersGrabberVisible: Bool = false
     public var isDismissable: Bool = true
+    public var allowsContentOutOfBounds: Bool = false
 
     private var presenter: BottomSheetPresenting
 
-    public init(content: UIViewController, useLegacyForcely: Bool = false) {
-        if (useLegacyForcely) {
+    public init(content: UIViewController, useLegacyForcely: Bool = false, allowsContentOutOfBounds: Bool = false) {
+        self.allowsContentOutOfBounds = allowsContentOutOfBounds
+
+        if useLegacyForcely || allowsContentOutOfBounds {
             presenter = LegacySheetPresenter(content: content)
         } else {
             if #available(iOS 16.0, *) {
@@ -65,6 +68,7 @@ public class BottomSheetPresenter {
         presenter.detents = detents
         presenter.prefersGrabberVisible = prefersGrabberVisible
         presenter.isDismissable = isDismissable
+        presenter.allowsContentOutOfBounds = allowsContentOutOfBounds
         presenter.presentSheet(from: parent, animated: animated)
     }
 }
@@ -84,5 +88,6 @@ protocol BottomSheetPresenting {
     var detents: [BottomSheetDetent] { get set }
     var prefersGrabberVisible: Bool { get set }
     var isDismissable: Bool { get set }
+    var allowsContentOutOfBounds: Bool { get set } // 시트 바깥 영역으로 뷰를 보여주는지 여부. clipsToBounds 설정을 위한 변수
     func presentSheet(from parent: UIViewController, animated: Bool)
 }

--- a/Sources/LegacySheetPresenter.swift
+++ b/Sources/LegacySheetPresenter.swift
@@ -11,6 +11,7 @@ class LegacySheetPresenter: BottomSheetPresenting {
     var detents: [BottomSheetDetent] = [.large]
     var prefersGrabberVisible: Bool = false
     var isDismissable: Bool = true
+    var allowsContentOutOfBounds: Bool = false
 
     private let content: UIViewController
 
@@ -24,6 +25,7 @@ class LegacySheetPresenter: BottomSheetPresenting {
             detents: detents,
             grabber: prefersGrabberVisible,
             isDismissable: isDismissable,
+            clipsToBounds: !allowsContentOutOfBounds,
             parentViewSafeAreaInsets: parent.view.safeAreaInsets
         )
         sheetVC.modalPresentationStyle = .custom
@@ -52,6 +54,7 @@ class CustomBottomSheetViewController: UIViewController {
     private var currentDetent: BottomSheetDetent
     private let showGrabber: Bool
     private let isDismissable: Bool
+    private let clipsToBounds: Bool
     private let parentViewSafeAreaInsets: UIEdgeInsets
 
     let dimmedView = UIView()
@@ -60,12 +63,13 @@ class CustomBottomSheetViewController: UIViewController {
     private var containerHeight: CGFloat = 0.0
     private var containerViewHeightConstraint: NSLayoutConstraint?
 
-    init(content: UIViewController, detents: [BottomSheetDetent], grabber: Bool, isDismissable: Bool, parentViewSafeAreaInsets: UIEdgeInsets) {
+    init(content: UIViewController, detents: [BottomSheetDetent], grabber: Bool, isDismissable: Bool, clipsToBounds: Bool, parentViewSafeAreaInsets: UIEdgeInsets) {
         self.contentVC = content
         self.detents = detents
         self.currentDetent = detents.first ?? .large
         self.showGrabber = grabber
         self.isDismissable = isDismissable
+        self.clipsToBounds = clipsToBounds
         self.parentViewSafeAreaInsets = parentViewSafeAreaInsets
 
         super.init(nibName: nil, bundle: nil)
@@ -114,6 +118,7 @@ class CustomBottomSheetViewController: UIViewController {
         containerView.backgroundColor = .systemBackground
         containerView.layer.cornerRadius = 12
         containerView.layer.masksToBounds = true
+        containerView.clipsToBounds = self.clipsToBounds
         containerView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
         containerView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(containerView)

--- a/Sources/ModernSheetPresenter.swift
+++ b/Sources/ModernSheetPresenter.swift
@@ -13,6 +13,7 @@ class ModernSheetPresenter: BottomSheetPresenting {
     var detents: [BottomSheetDetent] = [.large]
     var prefersGrabberVisible: Bool = false
     var isDismissable: Bool = true
+    var allowsContentOutOfBounds: Bool = false // ModernSheetPresenter에서는 동작하지 않습니다. 항상 false로 설정됩니다.
 
     private let content: UIViewController
 


### PR DESCRIPTION
BottomSheet에 allowsContentOutOfBounds 변수를 하나 추가합니다.
Sheet 영역 밖으로 나오는 내부 content를 자르지 않고 볼 수 있게 해줍니다(clipsToBounds 값과 반대 개념입니다).
pageSheet로는 구현할 수 없어 무조건 LegacySheetPresenter로 넘깁니다.

++ 이때 sheet 위쪽에 cornerRadius가 안 먹는데, sheet 자체에는 이미 걸려있으므로 내부 content(여기서는 ColorViewController)에 cornerRadius를 같이 적용하면 해결됩니다.

<img width="425" height="920" alt="IMG_6116" src="https://github.com/user-attachments/assets/02d79fd8-b447-4374-a926-9682c120da44" />
